### PR TITLE
🔒 Add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lighthouse:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint-format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Added `permissions: contents: read` to both Lighthouse CI and PR validation workflows to limit GITHUB_TOKEN permissions and follow the principle of least privilege.

🤖 Generated with [Claude Code](https://claude.ai/code)

resolve: https://github.com/paveg/logbook/security/code-scanning/1, https://github.com/paveg/logbook/security/code-scanning/3