### PR TITLE
Fix ShareButtons visibility issues in development

### DIFF
--- a/src/components/ShareButtons.astro
+++ b/src/components/ShareButtons.astro
@@ -6,6 +6,11 @@ interface Props {
 
 const { title, url } = Astro.props;
 
+// Debug: Log the props in development
+if (import.meta.env.DEV) {
+  console.log('ShareButtons props:', { title, url });
+}
+
 // URL encode the parameters
 const encodedTitle = encodeURIComponent(title);
 const encodedUrl = encodeURIComponent(url);
@@ -13,6 +18,11 @@ const encodedUrl = encodeURIComponent(url);
 // Social media share URLs
 const twitterShareUrl = `https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`;
 const hatenaShareUrl = `https://b.hatena.ne.jp/entry/${encodedUrl}`;
+
+// Debug: Log the constructed URLs in development
+if (import.meta.env.DEV) {
+  console.log('Share URLs:', { twitterShareUrl, hatenaShareUrl });
+}
 ---
 
 <div class="share-buttons">
@@ -60,7 +70,7 @@ const hatenaShareUrl = `https://b.hatena.ne.jp/entry/${encodedUrl}`;
     height: 2.5rem;
     border-radius: 50%;
     border: 1px solid var(--color-border);
-    color: var(--color-text-light);
+    color: var(--color-text);
     background-color: transparent;
     text-decoration: none;
     transition: all 0.15s ease;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -25,7 +25,10 @@ const articleKeywords = [
 ].join(', ');
 
 // Create the full URL for this article
-const articleUrl = new URL(Astro.url.pathname, Astro.site).href;
+// In development, use localhost URL; in production, use the configured site URL
+const articleUrl = import.meta.env.DEV
+  ? `${Astro.url.origin}${Astro.url.pathname}`
+  : new URL(Astro.url.pathname, Astro.site).href;
 
 // Generate OGP image URL based on slug
 const ogImageUrl = Astro.props.slug


### PR DESCRIPTION
## Summary
- Fix URL construction for development vs production environments to ensure ShareButtons work on localhost
- Improve button visibility by changing color from light to normal text color
- Add debug logging in development mode for easier troubleshooting

## Test plan
- [x] Build completes successfully
- [x] Format and lint checks pass
- [x] ShareButtons should now be visible on localhost:4321
- [ ] Verify buttons work correctly in both light and dark themes
- [ ] Test share functionality for both Twitter and Hatena Bookmark

🤖 Generated with [Claude Code](https://claude.ai/code)